### PR TITLE
initial commit version 0.18.4

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+upload_channels:
+  - sfe1ed40
+channels:
+  - https://staging.continuum.io/prefect/fs/pip-tools-feedstock/pr2/5e39d2d
+  - https://staging.continuum.io/prefect/fs/toposort-feedstock/pr2/a523d7f
+  - https://staging.continuum.io/prefect/fs/anyconfig-feedstock/pr2/06f83ac

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,2 @@
 upload_channels:
   - sfe1ed40
-channels:
-  - https://staging.continuum.io/prefect/fs/pip-tools-feedstock/pr2/5e39d2d
-  - https://staging.continuum.io/prefect/fs/toposort-feedstock/pr2/a523d7f
-  - https://staging.continuum.io/prefect/fs/anyconfig-feedstock/pr2/06f83ac

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
   sha256: da219eaf10ed96909195dda53cb33c66a3e017012501d08f0da90ce1879a3364
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<38]
+  script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
   entry_points:
     - kedro = kedro.framework.cli:main
   number: 0
@@ -21,9 +21,11 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
+    - wheel
+    - setuptools
   run:
-    - python >=3.7
+    - python
     - anyconfig >=0.10.0
     - attrs >=21.3
     - python-build >=0.7.0
@@ -33,7 +35,6 @@ requirements:
     - dynaconf >=3.1.2,<4.0
     - fsspec >=2021.4
     - gitpython >=3.0
-    - importlib_metadata >=3.6,<7.0.0
     - importlib-metadata >=3.6,<7.0.0
     - importlib_resources >=1.3,<7.0.0
     - jmespath >=0.9.5
@@ -41,11 +42,11 @@ requirements:
     - omegaconf >=2.1.1
     - parse >=1.19.0
     - pip-tools >=6.5
-    - pluggy >=1.0,<1.3 # TODO: Uncap when dropping Python 3.7 support, see https://github.com/kedro-org/kedro/issues/2979
+    - pluggy >=1.0
     - pyyaml >=4.2,<7.0
     - rich >=12.0,<14.0
     - rope >=0.21,<2.0
-    - setuptools >=38.0
+    - setuptools >=65.5.1
     - toml >=0.10.0
     - toposort >=1.5
 
@@ -61,9 +62,10 @@ test:
 about:
   home: https://github.com/quantumblacklabs/kedro
   summary: A Python library that implements software engineering best-practice for data and ML pipelines.
+  license_family: Apache
   license: Apache-2.0
   license_file: LICENSE.md
-  doc_url: https://kedro.readthedocs.io/
+  doc_url: https://docs.kedro.org
   dev_url: https://github.com/quantumblacklabs/kedro
   description: A Python framework for creating reproducible, maintainable and modular data science code.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: da219eaf10ed96909195dda53cb33c66a3e017012501d08f0da90ce1879a3364
 
 build:
-  skip: True  # [py<38]
+  skip: True  # [py<38 or s390x]
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
   entry_points:
     - kedro = kedro.framework.cli:main


### PR DESCRIPTION
kedro 0.18.4  ❄️ 
- [upstream](https://github.com/kedro-org/kedro/blob/0.18.14)
- [requirements](https://github.com/kedro-org/kedro/blob/0.18.14/pyproject.toml)
- update CF recipe
- skip s390x as not need for snowflake
- skip python 3.7 as there are additional dependency constrains for pluggy
- IMO there are too many test dependencies to run the tests, https://github.com/kedro-org/kedro/blob/c3c93cb4786b4fd38c62baa2ec7f6fc73a63791e/setup.py#L135-L205

